### PR TITLE
Update wa2-proton-gstreamer-patch.sh to use the AV1 and opus codecs

### DIFF
--- a/README.org
+++ b/README.org
@@ -237,8 +237,11 @@ provides a test pattern in its place for the duration of the asset. Valve may
 not be able to package the needed gstreamer functionality in its Proton stack,
 but there is nothing stopping ~ffmpeg~ on the Steam Deck since ~ffmpeg~ is not
 being developed by Valve. We can use ffmpeg to convert all of White Album 2's
-movie assets into H.264 encoded mp4 files that Proton's gstreamer packaging will
+movie assets into AV1 encoded mp4 files that Proton's gstreamer packaging will
 have no issues handling.
+
+Valve documents their best practices regarding codecs:
+[[https://partner.steamgames.com/doc/steamdeck/proton#4]].
 
 I packaged a script in this repository to handle converting the movie assets of
 the game.

--- a/wa2-proton-gstreamer-patch.sh
+++ b/wa2-proton-gstreamer-patch.sh
@@ -14,13 +14,16 @@ WA2_DIR=$1
 # due to Windows VFS being case-insensitive and not causing issues for the
 # games. Use find -exec in place of an outer bash loop through the find results
 # to avoid whitespace in file paths from breaking the script logic.
+#
+# Follow Valve's best practices for codecs.
+# https://partner.steamgames.com/doc/steamdeck/proton#4
 find "$WA2_DIR" -type f -iname 'mv*.pak' -exec sh -c '
     for mv_pak; do
         if [ -f "${mv_pak}.old" ]; then
             echo "${mv_pak} already converted to mp4..."
         else
             echo "Converting ${mv_pak} to mp4..."
-            ffmpeg -i "$mv_pak" "${mv_pak}.mp4"
+            ffmpeg -i "$mv_pak" "-c:v" "libsvtav1" "-c:a" "libopus" "${mv_pak}.mp4"
             mv "$mv_pak" "${mv_pak}.old"
             mv "${mv_pak}.mp4" "$mv_pak"
         fi


### PR DESCRIPTION
Valve documents which codecs are preferred for Proton support. It appears licensing involving H.264 has caused degradation in Proton's support for the encoding.